### PR TITLE
Modified Early labels not shown when checked in

### DIFF
--- a/components/Client/ClientCard/ClientCard.tsx
+++ b/components/Client/ClientCard/ClientCard.tsx
@@ -38,7 +38,7 @@ export default function ClientCard({ client }: { client: Client }) {
 
             <div className={styles.detailsContainer}>
                 <div className={styles.status}>
-                    {!!settings && !validated && (
+                    {!!settings && !validated && !client.isCheckedIn && (
                         <h3 className={styles.early}>Early</h3>
                     )}
                     {!!isBanned && <h3 className={styles.banned}>Banned</h3>}
@@ -48,13 +48,16 @@ export default function ClientCard({ client }: { client: Client }) {
                     birthday && toLicenseDateString(birthday)
                 )}
                 {!!daysVisitLeft &&
+                    !client.isCheckedIn &&
                     createField('Early by ', daysVisitLeft + ' days')}
                 {!!daysBackpackLeft &&
+                    !client.isCheckedIn &&
                     createField(
                         'Backpack ',
                         daysBackpackLeft + ' days remaining'
                     )}
                 {!!daysSleepingBagLeft &&
+                    !client.isCheckedIn &&
                     createField(
                         'Sleeping Bag ',
                         daysSleepingBagLeft + ' days remaining'


### PR DESCRIPTION
Added !client.isCheckedIn condition to the Early labels in ClientCard.tsx. 

During checked in:
![image](https://github.com/Kevinjchang98/St-Francis/assets/98987608/41815745-1669-431d-9bca-3198900540d2)

After checked out:
![image](https://github.com/Kevinjchang98/St-Francis/assets/98987608/321b77a3-fe9f-4efd-b17f-e7f1beeb59bb)
