### PR TITLE
Improve ORCA and item-based countdowns for checkin process

### DIFF
--- a/__tests__/app/checkin/__snapshots__/Checkin.test.tsx.snap
+++ b/__tests__/app/checkin/__snapshots__/Checkin.test.tsx.snap
@@ -529,6 +529,15 @@ exports[`CheckedIn should match snapshot when clientData fetched 1`] = `
            day(s) left
         </span>
       </h4>
+      <h4>
+        Last Orca Card:
+         
+        <span>
+           
+          | 
+           day(s) left
+        </span>
+      </h4>
       <div
         className="rowContainer"
       >

--- a/__tests__/components/Client/ClientSearchForm/ClientSearchForm.test.tsx
+++ b/__tests__/components/Client/ClientSearchForm/ClientSearchForm.test.tsx
@@ -23,7 +23,7 @@ describe('Client Info Form Component', () => {
 
     it('renders correctly without initial data', async () => {
         await act(async () => {
-            render(<ClientSearchForm onSubmit={() => {}} />);
+            render(<ClientSearchForm onSubmit={() => {}} isLoading={false} />);
         });
         const title = screen.queryByRole('heading', {
             name: 'Lookup Client',
@@ -44,22 +44,27 @@ describe('Client Info Form Component', () => {
                 <ClientSearchForm
                     onSubmit={mockSubmit}
                     onClear={mockOnClear}
-                    initialFields={{ filterByBirthday: true,  ...mockClient}}
+                    isLoading={false}
                 />
             );
         });
         const searchBtn = screen.queryByText('Search') as HTMLButtonElement;
         const clearBtn = screen.queryByText('Clear') as HTMLButtonElement;
-        const birthdayInput = screen.queryByLabelText('Birthday') as HTMLInputElement;
-        
+        const birthdayInput = screen.queryByLabelText(
+            'Birthday'
+        ) as HTMLInputElement;
+
+        // Simulate user input
+        fireEvent.change(birthdayInput, {
+            target: { value: mockClient.birthday },
+        });
+
         fireEvent.click(searchBtn);
         expect(mockSubmit).toHaveBeenCalledTimes(1);
         expect(birthdayInput.value).toBe(mockClient.birthday);
-        
+
         fireEvent.click(clearBtn);
         expect(mockOnClear).toHaveBeenCalledTimes(1);
         expect(birthdayInput.value).toBe('');
     });
-
-    //TODO: test checkbox
 });

--- a/__tests__/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
+++ b/__tests__/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
@@ -56,6 +56,23 @@ exports[`SettingsForm should match snapshot 1`] = `
   />
   <br />
   <label
+    htmlFor="orcaCardTheshold"
+  >
+    <h2>
+      Orca Card Threshold
+    </h2>
+  </label>
+  <input
+    id="orcaCardThreshold"
+    min="0"
+    name="orcaCardThreshold"
+    onChange={[Function]}
+    required={true}
+    type="number"
+    value="0"
+  />
+  <br />
+  <label
     htmlFor="earlyOverride"
   >
     <h2>

--- a/__tests__/utils/validtate.ts
+++ b/__tests__/utils/validtate.ts
@@ -23,15 +23,15 @@ describe('validateClient', () => {
         earlyOverride: false,
     };
     (getSettings as jest.Mock).mockReturnValue(mockSettings);
-    it('should validate eligible client', () => {
-        const result = validateClient(mockClient, mockSettings);
+    it('should validate eligible client', async () => {
+        const result = await validateClient(mockClient, mockSettings, []);
         expect(result?.data?.daysVisitLeft).toBe(0);
         expect(result?.data?.daysBackpackLeft).toBe(0);
         expect(result?.data?.daysSleepingBagLeft).toBe(0);
         expect(result.validated).toBe(true);
     });
-    it('shoudld validate ineligible client', () => {
-        const result = validateClient(
+    it('shoudld validate ineligible client', async () => {
+        const result = await validateClient(
             {
                 ...mockClient,
                 lastVisit: Timestamp.fromDate(new Date()),
@@ -43,23 +43,28 @@ describe('validateClient', () => {
                 daysEarlyThreshold: 10,
                 backpackThreshold: 10,
                 sleepingBagThreshold: 10,
-            }
+            },
+            []
         );
-        expect(result?.data?.daysVisitLeft).toBe(10);
+        expect(result?.data?.daysVisitLeft).toBe(0);
         expect(result?.data?.daysBackpackLeft).toBe(10);
         expect(result?.data?.daysSleepingBagLeft).toBe(10);
         expect(result.validated).toBe(false);
     });
-    it('should validate failed if no client', () => {
-        const result = validateClient(null, mockSettings);
+    it('should validate failed if no client', async () => {
+        const result = await validateClient(null, mockSettings, []);
         expect(result.validated).toBe(false);
     });
 
-    it('should bypass validation if earlyOverride is true', () => {
-        const result = validateClient(mockClient, {
-            ...mockSettings,
-            earlyOverride: true,
-        });
+    it('should bypass validation if earlyOverride is true', async () => {
+        const result = await validateClient(
+            mockClient,
+            {
+                ...mockSettings,
+                earlyOverride: true,
+            },
+            []
+        );
         expect(result.validated).toBe(true);
     });
 });

--- a/app/checkedin/page.tsx
+++ b/app/checkedin/page.tsx
@@ -16,6 +16,7 @@ export default function CheckedIn() {
             noDataMessage="No clients are currently checked in"
             title="Checked in clients"
             isLoading={isLoading}
+            visits={undefined}
         />
     );
 }

--- a/app/checkout/[userId]/page.tsx
+++ b/app/checkout/[userId]/page.tsx
@@ -47,8 +47,9 @@ export default function CheckOut({ params }: CheckOutProps) {
     // Sets isCheckedIn status to false then gets updated client data
     const checkOut = async (visitData: Visit) => {
         await updateVisit(visitData, params.userId);
+
         const client = await updateClient({
-            ...clientData,
+            id: params.userId,
             isCheckedIn: false,
         });
         updateVisitCache(params.userId, visitData);

--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -132,7 +132,10 @@ export default function Profile({ params }: ProfileProps) {
                         </Link>
                     )}
                 </div>
-                <ClientProfileInfo client={clientData} />
+                <ClientProfileInfo
+                    client={clientData}
+                    visitsData={visitsData}
+                />
             </div>
 
             <div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -27,7 +27,7 @@ export default function SettingsPage() {
             <SettingsForm
                 onSubmit={handleSubmit}
                 initialSettings={settings}
-                key={settings?.backpackThreshold}
+                key={settings?.backpackThreshold} // TODO: remove this when form is refactored
             />
         </div>
     );

--- a/components/Client/ClientCard/ClientCard.tsx
+++ b/components/Client/ClientCard/ClientCard.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/UI';
 import { useSettings } from '@/hooks/index';
 import type { VisitWithClientId } from '@/types/index';
 import { toLicenseDateString, validateClient } from '@/utils/index';
-import type { Client } from 'models';
+import type { Client, Settings } from 'models';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import styles from './ClientCard.module.css';
@@ -17,9 +17,6 @@ type PropsType = {
 export default function ClientCard({ client, clientVisits }: PropsType) {
     const { id, firstName, lastName, birthday, notes, isBanned } = client;
     const { settings } = useSettings();
-
-    const [data, setData] = useState<any>(null);
-    const [validated, setValidated] = useState<boolean>(false);
 
     const createField = (label: string, value?: string | number | null) => {
         return (
@@ -37,15 +34,7 @@ export default function ClientCard({ client, clientVisits }: PropsType) {
 
     if (!settings) return <Spinner />;
 
-    useEffect(() => {
-        const fetchData = async () => {
-            const result = await validateClient(client, settings, clientVisits);
-            setData(result.data);
-            setValidated(result.validated);
-        };
-
-        fetchData();
-    }, [client, settings, clientVisits]);
+    const { validated, data } = validateClient(client, settings, clientVisits);
 
     const {
         daysVisitLeft,

--- a/components/Client/ClientList/ClientList.tsx
+++ b/components/Client/ClientList/ClientList.tsx
@@ -1,9 +1,11 @@
 import { ClientCard, ClientCardSkeleton } from '@/components/Client/index';
 import type { Client } from '@/models/index';
+import type { VisitWithClientId } from '@/types/index';
 import styles from './ClientList.module.css';
 
 type ClientListProps = {
     clients: Array<Client>;
+    visits: VisitWithClientId[] | undefined;
     noDataMessage?: string;
     title?: string;
     isLoading?: boolean;
@@ -14,6 +16,7 @@ export default function ClientList(props: ClientListProps) {
         clients,
         noDataMessage = 'No Clients',
         title,
+        visits,
         isLoading = false,
     } = props;
 
@@ -32,7 +35,13 @@ export default function ClientList(props: ClientListProps) {
         clientList = (
             <>
                 {clients.map((client) => (
-                    <ClientCard client={client} key={client.id} />
+                    <ClientCard
+                        client={client}
+                        key={client.id}
+                        clientVisits={visits?.filter(
+                            (el) => el.clientId == client.id
+                        )}
+                    />
                 ))}
             </>
         );

--- a/components/Client/ClientProfileInfo/ClientProfileInfo.tsx
+++ b/components/Client/ClientProfileInfo/ClientProfileInfo.tsx
@@ -1,15 +1,18 @@
 'use client';
 
-import { Client } from '@/models/index';
+import { Client, Visit } from '@/models/index';
 import { toLicenseDateString, formatDate } from '@/utils/index';
+import { Timestamp } from 'firebase/firestore';
 import { format } from 'path';
 import styles from './ClientProfileInfo.module.css';
 
 type ClientProfileInfoProps = {
     client?: Client;
+    visitsData?: Visit[];
 };
+
 const ClientProfileInfo = (props: ClientProfileInfoProps) => {
-    const { client } = props;
+    const { client, visitsData } = props;
     if (!client) return null;
     const {
         birthday,
@@ -21,6 +24,7 @@ const ClientProfileInfo = (props: ClientProfileInfoProps) => {
         lastBackpack,
         lastSleepingBag,
         notes,
+        lastOrcaCard,
     } = client;
 
     const createField = (label: string, value?: string | number | null) => {
@@ -33,6 +37,19 @@ const ClientProfileInfo = (props: ClientProfileInfoProps) => {
             )) ||
             null
         );
+    };
+
+    const getLastOrcaCardVisit = () => {
+        if (lastOrcaCard) return lastOrcaCard;
+        if (visitsData) {
+            const orcaCardVisits = visitsData.filter(
+                (visit) => visit.orcaCard && visit.orcaCard > 0
+            );
+
+            return orcaCardVisits.length > 0
+                ? orcaCardVisits[0].createdAt
+                : null;
+        }
     };
 
     return (
@@ -54,6 +71,11 @@ const ClientProfileInfo = (props: ClientProfileInfoProps) => {
                 {createField(
                     'Last sleeping bag',
                     lastSleepingBag && formatDate(lastSleepingBag)
+                )}
+                {createField(
+                    'Last Orca Card',
+                    getLastOrcaCardVisit() &&
+                        formatDate(getLastOrcaCardVisit() as Timestamp)
                 )}
             </div>
             {createField('Notes', notes)}

--- a/components/Client/ClientSearch/ClientSearch.tsx
+++ b/components/Client/ClientSearch/ClientSearch.tsx
@@ -1,60 +1,31 @@
 'use client';
+
 import { ClientList, ClientSearchForm } from '@/components/Client/index';
-import type { DocFilter, FilterObject } from '@/utils/index';
-import { CLIENTS_PATH, listClients } from '@/utils/index';
-import type { Client } from 'models';
-import { useEffect, useState } from 'react';
-import { useQuery, useQueryClient } from 'react-query';
-import { useAlert } from '@/hooks/index';
+import type { DocFilter } from '@/utils/index';
+import { useGetClientsSearch } from './hooks';
+
 export default function ClientsSearch() {
-    const [fields, setFields] = useState<DocFilter>();
-    const queryClient = useQueryClient();
-    const [, setAlert] = useAlert();
-    const { data, isLoading, refetch } = useQuery({
-        queryKey: [CLIENTS_PATH, 'searched'],
-        queryFn: async () => {
-            let clients: Array<Client> = [];
-            const filter = { ...fields };
-            if (filter?.filterByBirthday && !filter.birthday) {
-                setAlert({
-                    message: 'invalid date of birth',
-                    type: 'error',
-                });
-                return { clients, fields };
-            }
-            if (filter?.filterByBirthday && filter?.birthday) {
-                filter.birthday = new Date(filter.birthday as string);
-                delete filter.filterByBirthday;
-            }
-            if (!Object.keys(filter).length)
-                filter.updatedAt = {
-                    opStr: '>=',
-                    value: new Date(new Date().toDateString()),
-                } as FilterObject;
-            clients = await listClients(filter);
-            return { clients, fields };
-        },
-        enabled: false,
-    });
+    const { mutateAsync, isLoading, clients, visits, setClients } =
+        useGetClientsSearch();
 
-    const handleClear = () =>
-        queryClient.resetQueries([CLIENTS_PATH, 'searched']);
+    const handleSubmit = (formFields: DocFilter) => {
+        mutateAsync(formFields);
+    };
 
-    useEffect(() => {
-        if (fields) refetch();
-        // TODO: remove useEffect approach
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [fields]);
+    const handleClear = () => {
+        setClients([]);
+    };
 
     return (
         <>
             <ClientSearchForm
-                onSubmit={setFields}
+                onSubmit={handleSubmit}
+                isLoading={isLoading}
                 onClear={handleClear}
-                initialFields={data?.fields}
             />
             <ClientList
-                clients={(data?.clients as Client[]) || []}
+                clients={clients}
+                visits={visits}
                 noDataMessage="No Matching Clients"
                 isLoading={isLoading}
             />

--- a/components/Client/ClientSearch/hooks.ts
+++ b/components/Client/ClientSearch/hooks.ts
@@ -1,0 +1,78 @@
+import { useMutation } from 'react-query';
+import { useState } from 'react';
+import { subDays } from 'date-fns';
+import useAlert from '@/hooks/useAlert';
+import type { Client } from '@/models/index';
+import { DocFilter, FilterObject, listVisits } from '@/utils/index';
+import { listClients, getSettings } from '@/utils/index';
+import type { VisitWithClientId } from '@/types/visits';
+
+export const useGetClientsSearch = () => {
+    const [, setAlert] = useAlert();
+    const [clients, setClients] = useState<Client[]>([]);
+    const [visits, setVisits] = useState<VisitWithClientId[]>([]);
+
+    const { mutateAsync, isLoading } = useMutation({
+        mutationFn: async (fields: DocFilter) => {
+            const filter = { ...fields };
+            if (filter?.filterByBirthday && !filter.birthday) {
+                setAlert({
+                    message: 'invalid date of birth',
+                    type: 'error',
+                });
+            }
+            if (filter?.filterByBirthday && filter?.birthday) {
+                filter.birthday = new Date(filter.birthday as string);
+                delete filter.filterByBirthday;
+            }
+            if (!Object.keys(filter).length)
+                filter.updatedAt = {
+                    opStr: '>=',
+                    value: new Date(new Date().toDateString()),
+                } as FilterObject;
+            const clients = await listClients(filter);
+
+            // fetch visit by clients
+            const userIds = clients.map((client) => client.id);
+            const visits = await getVisitsByClientIds(userIds);
+            setVisits(visits);
+            setClients(clients);
+        },
+    });
+
+    return { mutateAsync, isLoading, clients, visits, setClients };
+};
+
+const VISITS_LIMIT = 10; //  visit limit per client
+
+export const getVisitsByClientIds = async (userIds: string[]) => {
+    const ORCA_CARD_TRESHOLD = (await getSettings()).orcaCardThreshold;
+    if (!ORCA_CARD_TRESHOLD) {
+        return [];
+    }
+
+    const pastDate = subDays(new Date(), ORCA_CARD_TRESHOLD);
+
+    const promises = userIds.map(async (userId) => {
+        try {
+            const visits = await listVisits(
+                userId,
+                {
+                    createdAt: { opStr: '>=', value: pastDate },
+                },
+                VISITS_LIMIT
+            );
+
+            // Add the clientId to each visit
+            return visits.map((visit) => ({ ...visit, clientId: userId }));
+        } catch (error) {
+            return [];
+        }
+    });
+
+    // Resolve all promises and flatten the results
+    const results = await Promise.all(promises);
+    const visits = results.flat();
+
+    return visits;
+};

--- a/components/Client/ClientSearchForm/ClientSearchForm.tsx
+++ b/components/Client/ClientSearchForm/ClientSearchForm.tsx
@@ -1,22 +1,19 @@
 'use client';
+
+import { useState } from 'react';
 import { Button } from '@/components/UI';
 import type { DocFilter } from '@/utils/index';
 import Image from 'next/image';
-import { useState } from 'react';
+import Spinner from '@/components/Spinner/Spinner';
 import styles from './ClientSearchForm.module.css';
 
 type ClientSearchFormProps = {
     onSubmit: (fields: DocFilter) => void;
+    isLoading: boolean;
     onClear?: () => void;
-    initialFields?: {
-        firstNameLower?: string;
-        lastNameLower?: string;
-        birthday?: string;
-        filterByBirthday?: boolean;
-    };
 };
 export default function ClientSearchForm(props: ClientSearchFormProps) {
-    const { onSubmit, onClear, initialFields } = props;
+    const { onSubmit, onClear, isLoading } = props;
 
     const defaultData = {
         firstName: '',
@@ -26,11 +23,10 @@ export default function ClientSearchForm(props: ClientSearchFormProps) {
     };
 
     const [clientData, setClientData] = useState({
-        birthday: initialFields?.birthday || defaultData.birthday,
-        filterByBirthday:
-            initialFields?.filterByBirthday || defaultData.filterByBirthday,
-        firstName: initialFields?.firstNameLower || '',
-        lastName: initialFields?.lastNameLower || '',
+        birthday: defaultData.birthday,
+        filterByBirthday: defaultData.filterByBirthday,
+        firstName: '',
+        lastName: '',
     });
 
     const handleSubmit = (e: React.FormEvent) => {
@@ -64,6 +60,28 @@ export default function ClientSearchForm(props: ClientSearchFormProps) {
             });
         } else {
             setClientData({ ...clientData, [e.target.name]: value });
+        }
+    };
+
+    const renderSubmitButton = () => {
+        if (isLoading) {
+            return (
+                <Button disabled>
+                    <Spinner variant="small" />
+                </Button>
+            );
+        } else {
+            return (
+                <Button type="submit">
+                    Search
+                    <Image
+                        src="/search.svg"
+                        alt="client-search-icon"
+                        width="20"
+                        height="20"
+                    />
+                </Button>
+            );
         }
     };
 
@@ -110,15 +128,7 @@ export default function ClientSearchForm(props: ClientSearchFormProps) {
                 </div>
 
                 <div className={styles.formControls}>
-                    <Button type="submit">
-                        Search
-                        <Image
-                            src="/search.svg"
-                            alt="client-search-icon"
-                            width="20"
-                            height="20"
-                        />
-                    </Button>
+                    {renderSubmitButton()}
                     <Button type="button" onClick={handleClear}>
                         Clear
                     </Button>

--- a/components/Settings/SettingsForm.tsx
+++ b/components/Settings/SettingsForm.tsx
@@ -12,6 +12,7 @@ type SettingsForm = {
     daysEarlyThreshold: string;
     backpackThreshold: string;
     sleepingBagThreshold: string;
+    orcaCardThreshold: string;
     earlyOverride: boolean;
 };
 
@@ -27,6 +28,8 @@ function SettingsForm(props: SettingsFormProps) {
         sleepingBagThreshold:
             initialSettings?.sleepingBagThreshold?.toString() || '0',
         earlyOverride: !!initialSettings?.earlyOverride,
+        orcaCardThreshold:
+            initialSettings?.orcaCardThreshold?.toString() || '0',
     } as SettingsForm;
     const [settings, setSettings] = useState(defaultSettings);
 
@@ -45,6 +48,7 @@ function SettingsForm(props: SettingsFormProps) {
             daysEarlyThreshold: parseInt(settings.daysEarlyThreshold),
             backpackThreshold: parseInt(settings.backpackThreshold),
             sleepingBagThreshold: parseInt(settings.sleepingBagThreshold),
+            orcaCardThreshold: parseInt(settings.orcaCardThreshold),
         };
         onSubmit && onSubmit(settingsData);
     };
@@ -87,6 +91,20 @@ function SettingsForm(props: SettingsFormProps) {
                 name="sleepingBagThreshold"
                 id="sleepingBagThreshold"
                 value={settings.sleepingBagThreshold}
+                onChange={handleChange}
+                required
+                min="0"
+            />
+            <br />
+
+            <label htmlFor="orcaCardTheshold">
+                <h2>Orca Card Threshold</h2>
+            </label>
+            <input
+                type="number"
+                name="orcaCardThreshold"
+                id="orcaCardThreshold"
+                value={settings.orcaCardThreshold}
                 onChange={handleChange}
                 required
                 min="0"

--- a/models/index.d.ts
+++ b/models/index.d.ts
@@ -24,6 +24,7 @@ export declare type Client = {
     readonly lastNameLower?: string | null;
     readonly firstNameLower?: string | null;
     readonly lastSleepingBag?: Timestamp | null;
+    readonly lastOrcaCard?: Timestamp | null;
     readonly idv1?: string;
 };
 
@@ -60,6 +61,7 @@ export declare type Settings = {
     readonly daysEarlyThreshold?: number;
     readonly backpackThreshold?: number;
     readonly sleepingBagThreshold?: number;
+    readonly orcaCardThreshold?: number;
     readonly earlyOverride?: boolean;
     readonly createdAt?: Timestamp | null;
     readonly updatedAt?: Timestamp | null;

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,1 @@
+export type { VisitWithClientId } from './visits';

--- a/types/visits.ts
+++ b/types/visits.ts
@@ -1,0 +1,3 @@
+import { Visit } from '@/models/index';
+
+export type VisitWithClientId = Visit & { clientId: string };

--- a/utils/mutations.ts
+++ b/utils/mutations.ts
@@ -39,12 +39,23 @@ export const reviseClient = async (clientID: string) => {
     const lastSleepingBag =
         (await listVisits(clientID, { sleepingBag: true }, 1))[0]?.createdAt ||
         null;
+    const lastOrcaCard =
+        (
+            await listVisits(
+                clientID,
+                {
+                    orcaCard: [{ opStr: '>', value: 0 }],
+                },
+                1
+            )
+        )[0]?.createdAt || null;
 
     return await updateClient({
         id: clientID,
         lastBackpack,
         lastSleepingBag,
         lastVisit,
+        lastOrcaCard,
     });
 };
 

--- a/utils/validate.ts
+++ b/utils/validate.ts
@@ -8,7 +8,7 @@ import { subDays, isAfter } from 'date-fns';
  * @param settings Settings document
  * @returns validated result and validation data (days left)
  */
-export const validateClient = async (
+export const validateClient = (
     client: Client | null = null,
     settings: Settings,
     clientVisits: Visit[] | undefined
@@ -26,7 +26,7 @@ export const validateClient = async (
     const { lastBackpack, lastSleepingBag, lastOrcaCard } = client;
 
     // Calculate days duration
-    const daysVisit = daysBetween(await findShoppingWithDate(clientVisits));
+    const daysVisit = daysBetween(findShoppingWithDate(clientVisits, settings));
     const daysBackpack = daysBetween(lastBackpack?.toDate());
     const daysSleepingBag = daysBetween(lastSleepingBag?.toDate());
     const daysOrcaCard = daysBetween(
@@ -63,8 +63,11 @@ const daysBetween = (from: Date | undefined, to: Date = new Date()) => {
 
 const toUint = (value: number) => Math.round(value > 0 ? value : 0);
 
-const findShoppingWithDate = async (clientVisits: Visit[] | undefined) => {
-    const shopping_theshold = (await getSettings())?.daysEarlyThreshold;
+const findShoppingWithDate = (
+    clientVisits: Visit[] | undefined,
+    settings: Settings
+) => {
+    const shopping_theshold = settings.daysEarlyThreshold;
     if (!shopping_theshold) return;
     const treshholdDate = subDays(new Date(), shopping_theshold);
     const visitWithShopping = clientVisits?.find((visit) => {

--- a/utils/validate.ts
+++ b/utils/validate.ts
@@ -1,5 +1,6 @@
-import { Client, Settings } from '@/models/index';
+import { Client, Settings, Visit } from '@/models/index';
 import { getSettings } from '@/utils/index';
+import { subDays, isAfter } from 'date-fns';
 
 /**
  * Calculate validation data (days between last and threshold)
@@ -7,31 +8,41 @@ import { getSettings } from '@/utils/index';
  * @param settings Settings document
  * @returns validated result and validation data (days left)
  */
-export const validateClient = (
+export const validateClient = async (
     client: Client | null = null,
-    settings: Settings
+    settings: Settings,
+    clientVisits: Visit[] | undefined
 ) => {
-    // TODO: Validate for edge cases with daylight savings and different timezones
     if (!client || !settings) return { validated: false };
     const {
         daysEarlyThreshold = 0,
         backpackThreshold = 0,
         sleepingBagThreshold = 0,
         earlyOverride = false,
+        orcaCardThreshold = 0,
     } = settings;
     // Bypass validation if earlyOverride is true
     if (earlyOverride) return { validated: true };
-    const { lastVisit, lastBackpack, lastSleepingBag } = client;
+    const { lastBackpack, lastSleepingBag, lastOrcaCard } = client;
+
     // Calculate days duration
-    const daysVisit = daysBetween(lastVisit?.toDate());
+    const daysVisit = daysBetween(await findShoppingWithDate(clientVisits));
     const daysBackpack = daysBetween(lastBackpack?.toDate());
     const daysSleepingBag = daysBetween(lastSleepingBag?.toDate());
+    const daysOrcaCard = daysBetween(
+        lastOrcaCard?.toDate() ?? findLastOrcaCardDate(clientVisits)
+    );
+
     // Calculate days left for eligibility (if negative, default to 0)
     const daysVisitLeft = toUint(daysEarlyThreshold - daysVisit);
     const daysBackpackLeft = toUint(backpackThreshold - daysBackpack);
     const daysSleepingBagLeft = toUint(sleepingBagThreshold - daysSleepingBag);
+    const daysOrcaCardLeft = toUint(orcaCardThreshold - daysOrcaCard);
     const validated =
-        !daysVisitLeft && !daysBackpackLeft && !daysSleepingBagLeft;
+        !daysVisitLeft &&
+        !daysBackpackLeft &&
+        !daysSleepingBagLeft &&
+        !daysOrcaCardLeft;
 
     return {
         validated,
@@ -39,6 +50,7 @@ export const validateClient = (
             daysVisitLeft,
             daysBackpackLeft,
             daysSleepingBagLeft,
+            daysOrcaCardLeft,
         },
     };
 };
@@ -50,3 +62,37 @@ const daysBetween = (from: Date | undefined, to: Date = new Date()) => {
 };
 
 const toUint = (value: number) => Math.round(value > 0 ? value : 0);
+
+const findShoppingWithDate = async (clientVisits: Visit[] | undefined) => {
+    const shopping_theshold = (await getSettings())?.daysEarlyThreshold;
+    if (!shopping_theshold) return;
+    const treshholdDate = subDays(new Date(), shopping_theshold);
+    const visitWithShopping = clientVisits?.find((visit) => {
+        if (!visit.createdAt) return;
+        return (
+            ((visit.mensQ && visit.mensQ > 0) ||
+                (visit.kidsQ && visit.kidsQ > 0) ||
+                (visit.diaper && visit.diaper > 0) ||
+                (visit.womensQ && visit.womensQ > 0) ||
+                (visit.giftCard && visit.giftCard > 0) ||
+                (visit.busTicket && visit.busTicket > 0) ||
+                visit.householdItem || // If householdItem is truthy
+                (visit.householdItemQ && visit.householdItemQ > 0) ||
+                (visit.financialAssistance && visit.financialAssistance > 0)) &&
+            isAfter(visit.createdAt.toDate(), treshholdDate)
+        );
+    });
+
+    return visitWithShopping
+        ? visitWithShopping.createdAt?.toDate()
+        : undefined;
+};
+
+const findLastOrcaCardDate = (clientVisits: Visit[] | undefined) => {
+    const lastOrcaCard = clientVisits?.find((visit) => {
+        if (!visit.createdAt) return;
+        return visit.orcaCard && visit.orcaCard > 0;
+    });
+
+    return lastOrcaCard ? lastOrcaCard.createdAt?.toDate() : undefined;
+};


### PR DESCRIPTION
Related to issue #152
- added Orca card countdown to the client's card when searching for a client. If the client is early for the Orca, it will appear on the card like other countdowns already in place.
- added Orca card on the Settings page.
- added countdown separation. Previously, countdowns for shopping and sleeping bag / backpack were triggered together, causing eligibility issues. Now, countdowns are separated so that only the relevant one is activated based on what the client took.
- fixed countdown issue after check-in: bug where the countdown was being updated even if a client checked in but the requested item (like a sleeping bag) was unavailable is fixed. Now, countdowns will only activate if the item is actually available and taken.
- added spinner for search to avoid needing multiple clicks on the search button.
- added last Orca card info to Profile and Force check-in modal.
- updated tests.